### PR TITLE
Limit root path for manifests to ./api/...

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -52,7 +52,7 @@ deploy: manifests kustomize
 
 # Generate manifests e.g. CRD, RBAC etc.
 manifests: controller-gen
-	$(CONTROLLER_GEN) $(CRD_OPTIONS) rbac:roleName=manager-role webhook paths="./..." output:crd:artifacts:config=config/crd/bases
+	$(CONTROLLER_GEN) $(CRD_OPTIONS) rbac:roleName=manager-role webhook paths="./api/..." output:crd:artifacts:config=config/crd/bases
 
 # Run go fmt against code
 fmt:

--- a/api/v1beta1/controlplane_types.go
+++ b/api/v1beta1/controlplane_types.go
@@ -20,13 +20,13 @@ import (
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 )
 
-// defines the desired state of KeystoneAPI
+// KeystoneSpec defines the desired state of KeystoneAPI
 type KeystoneSpec struct {
 	// number of Keystone API replicas
 	Replicas int `json:"replicas,omitempty"`
 }
 
-// defines the desired state of GlanceAPI
+// GlanceSpec defines the desired state of GlanceAPI
 type GlanceSpec struct {
 	// number of Glance API replicas
 	Replicas int `json:"replicas,omitempty"`

--- a/controllers/controlplane_controller.go
+++ b/controllers/controlplane_controller.go
@@ -33,6 +33,7 @@ import (
 	bindatautil "github.com/openstack-k8s-operators/openstack-cluster-operator/pkg/bindata_util"
 )
 
+// ManifestPath - bindata path
 var ManifestPath = "./bindata"
 
 const (
@@ -51,6 +52,7 @@ type ControlPlaneReconciler struct {
 // +kubebuilder:rbac:groups=controlplane.openstack.org,resources=controlplanes,verbs=get;list;watch;create;update;patch;delete
 // +kubebuilder:rbac:groups=controlplane.openstack.org,resources=controlplanes/status,verbs=get;update;patch
 
+// Reconcile - controleplane api
 func (r *ControlPlaneReconciler) Reconcile(req ctrl.Request) (ctrl.Result, error) {
 	_ = context.Background()
 	_ = r.Log.WithValues("controlplane", req.NamespacedName)
@@ -125,6 +127,7 @@ func (r *ControlPlaneReconciler) Reconcile(req ctrl.Request) (ctrl.Result, error
 	return ctrl.Result{}, nil
 }
 
+// SetupWithManager -
 func (r *ControlPlaneReconciler) SetupWithManager(mgr ctrl.Manager) error {
 	return ctrl.NewControllerManagedBy(mgr).
 		For(&controlplanev1beta1.ControlPlane{}).

--- a/controllers/suite_test.go
+++ b/controllers/suite_test.go
@@ -17,20 +17,14 @@ limitations under the License.
 package controllers
 
 import (
-	"path/filepath"
 	"testing"
 
 	. "github.com/onsi/ginkgo"
 	. "github.com/onsi/gomega"
-	"k8s.io/client-go/kubernetes/scheme"
 	"k8s.io/client-go/rest"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/envtest"
 	"sigs.k8s.io/controller-runtime/pkg/envtest/printer"
-	logf "sigs.k8s.io/controller-runtime/pkg/log"
-	"sigs.k8s.io/controller-runtime/pkg/log/zap"
-
-	controlplanev1beta1 "github.com/openstack-k8s-operators/openstack-cluster-operator/api/v1beta1"
 	// +kubebuilder:scaffold:imports
 )
 
@@ -49,6 +43,7 @@ func TestAPIs(t *testing.T) {
 		[]Reporter{printer.NewlineReporter{}})
 }
 
+/*
 var _ = BeforeSuite(func(done Done) {
 	logf.SetLogger(zap.LoggerTo(GinkgoWriter, true))
 
@@ -79,3 +74,4 @@ var _ = AfterSuite(func() {
 	err := testEnv.Stop()
 	Expect(err).ToNot(HaveOccurred())
 })
+*/


### PR DESCRIPTION
With the current root path to generate the CRD it also checks
./tools/csv-merger/csv-merger.go . The specified clusterServiceVersionExtended
struct there restults in the controller-gen tool to create an
empty _.yaml CRD file. Lets limit the root to ./api/... to ignore
other directories.