### PR TITLE
Fix error passing namespace to csv-generator

### DIFF
--- a/scripts/build-manifests.sh
+++ b/scripts/build-manifests.sh
@@ -34,7 +34,7 @@ DEPLOY_DIR="${PROJECT_ROOT}/deploy"
 CSV_DIR="${DEPLOY_DIR}/olm-catalog/openstack-cluster/${CSV_VERSION}"
 
 OPERATOR_NAME="${NAME:-openstack-cluster-operator}"
-OPERATOR_NAMESPACE="${NAMESPACE:-openstack-cluster-operator}"
+OPERATOR_NAMESPACE="${NAMESPACE:-openstack}"
 OPERATOR_IMAGE="${OPERATOR_IMAGE:-quay.io/openstack-k8s-operators/openstack-cluster-operator:v0.0.1}"
 IMAGE_PULL_POLICY="${IMAGE_PULL_POLICY:-IfNotPresent}"
 
@@ -77,18 +77,15 @@ function gen_csv() {
   # Handle arguments
   local operatorName="$1" && shift
   local imagePullUrl="$1" && shift
-  local dumpCRDsArg="$1" && shift
   local operatorArgs="$@"
 
   # Handle important vars
   local csv="${operatorName}.${CSV_EXT}"
-  #local csvWithCRDs="${operatorName}.${CSV_CRD_EXT}"
-  local crds="${operatorName}.crds.yaml"
 
   # TODO: Use oc to run if cluster is available
   local containerBuildCmd="$CONTAINER_BUILD_CMD run --rm --entrypoint=/usr/local/bin/csv-generator ${imagePullUrl} ${operatorArgs}"
 
-  eval $containerBuildCmd > $csv
+  eval $containerBuildCmd > $csv || exit 1
 }
 
 function create_nova_csv() {


### PR DESCRIPTION
gen_csv took 3 fixed arguments, but we were only passing it 2. We were
also not using the third argument. This meant that the first entry in
operatorArgs was dropped, which was always --namespace=openstack. This
only worked because none of the csv-generators were validating their
input, and they all defaulted to openstack anyway.

Additionally the default namespace we were failing to set was
incorrectly set to "openstack-cluster-operator".

Additionally, because gen_csv is executed in a subshell the calling
shell's `set -e` had no effect. If the execution of a csv-generator
failed. This left no output for that generator with no indication of
what caused the error.