### PR TITLE
Fix perf operator API group name

### DIFF
--- a/pkg/operator/helpers.go
+++ b/pkg/operator/helpers.go
@@ -222,7 +222,7 @@ func getOperatorRules() *[]rbacv1.PolicyRule {
 		},
 		{
 			APIGroups: []string{
-				"performanceprofiles.performance.openshift.io",
+				"performance.openshift.io",
 			},
 			Resources: []string{
 				"*",


### PR DESCRIPTION
API group should not have a resource name prepended